### PR TITLE
Add engine state canonicalization and parity tests

### DIFF
--- a/nlhe/core/state_map.py
+++ b/nlhe/core/state_map.py
@@ -1,0 +1,77 @@
+"""Utilities for canonicalizing engine states for cross-engine comparison.
+
+This module provides helper functions to map :class:`GameState` objects into
+simple data structures made of built-in Python types.  The representation is
+stable and hashable which makes it convenient for equality checks between
+states produced by different engine implementations (e.g. the pure Python
+engine and the Rust backend).
+
+The main entry point is :func:`canonical_state` which converts a ``GameState``
+into a nested tuple.  Two states that are logically equivalent will map to the
+same canonical value even if they originate from different engine
+implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+from .types import GameState, PlayerState
+
+
+def _player_to_tuple(p: PlayerState, include_cards: bool) -> Tuple[Any, ...]:
+    """Convert a :class:`PlayerState` into a tuple of its public attributes."""
+    hole = p.hole if include_cards else None
+    return (hole, p.stack, p.bet, p.cont, p.status, p.rho)
+
+
+def canonical_state(s: GameState, *, include_cards: bool = True) -> Tuple[Any, ...]:
+    """Return a hashable canonical representation of ``s``.
+
+    Parameters
+    ----------
+    s:
+        The state to convert.
+    include_cards:
+        If ``True`` (default) the representation includes hole cards and the
+        remaining deck.  Set to ``False`` to ignore card identities when only
+        the betting state matters.
+    """
+
+    players = tuple(_player_to_tuple(p, include_cards) for p in s.players)
+    board = tuple(s.board) if include_cards else ()
+    undealt = tuple(s.undealt) if include_cards else ()
+    return (
+        s.button,
+        s.round_label,
+        board,
+        undealt,
+        players,
+        s.current_bet,
+        s.min_raise,
+        s.tau,
+        s.next_to_act,
+        s.step_idx,
+        s.pot,
+        s.sb,
+        s.bb,
+        tuple(tuple(log) for log in s.actions_log),
+    )
+
+
+def states_equal(a: GameState, b: GameState) -> bool:
+    """Determine if two ``GameState`` objects are equivalent.
+
+    Parameters
+    ----------
+    a, b:
+        The states to compare.
+
+    Returns
+    -------
+    bool
+        ``True`` if the states map to the same canonical representation,
+        ``False`` otherwise.
+    """
+
+    return canonical_state(a) == canonical_state(b)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on sys.path so `nlhe` can be imported when the
+# project is not installed as a package.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_engine_parity.py
+++ b/tests/test_engine_parity.py
@@ -1,0 +1,65 @@
+import random
+
+import pytest
+
+from nlhe.core.engine import NLHEngine as PyEngine
+from nlhe.core.state_map import canonical_state
+
+rs_mod = pytest.importorskip("nlhe.core.rs_engine")
+RsEngine = rs_mod.NLHEngine
+from nlhe.core.types import Action, ActionType
+
+
+def _sample_action(rng: random.Random, info):
+    """Sample a legal action using ``info`` describing legal moves."""
+    act = rng.choice(info.actions)
+    if act.kind is ActionType.RAISE_TO:
+        assert info.max_raise_to is not None
+        min_to = info.min_raise_to if info.min_raise_to is not None else info.max_raise_to
+        max_to = info.max_raise_to
+        if min_to >= max_to:
+            target = max_to
+        else:
+            target = rng.randint(min_to, max_to)
+        return Action(ActionType.RAISE_TO, target)
+    return act
+
+
+@pytest.mark.parametrize("seed", [0, 1])
+def test_python_vs_rust_engine_equivalence(seed: int):
+    py_rng = random.Random(seed)
+    rs_rng = random.Random(seed)
+    action_rng = random.Random(seed)
+
+    py = PyEngine(rng=py_rng)
+    rs = RsEngine(rng=rs_rng)
+
+    s_py = py.reset_hand(button=0)
+    s_rs = rs.reset_hand(button=0)
+    assert canonical_state(s_py, include_cards=False) == canonical_state(
+        s_rs, include_cards=False
+    )
+
+    for _ in range(200):
+        li_py = py.legal_actions(s_py)
+        li_rs = rs.legal_actions(s_rs)
+        assert li_py == li_rs
+        if not li_py.actions:
+            break
+        a = _sample_action(action_rng, li_py)
+        s_py, done_py, rew_py, _ = py.step(s_py, a)
+        s_rs, done_rs, rew_rs, _ = rs.step(s_rs, a)
+        assert done_py == done_rs
+        if done_py:
+            assert rew_py is not None and rew_rs is not None
+            assert len(rew_py) == len(rew_rs)
+            assert sum(rew_py) == 0 and sum(rew_rs) == 0
+        else:
+            assert rew_py is None and rew_rs is None
+        assert canonical_state(s_py, include_cards=False) == canonical_state(
+            s_rs, include_cards=False
+        )
+        assert s_py.pot == sum(p.cont for p in s_py.players)
+        assert s_py.current_bet == max(p.bet for p in s_py.players)
+        if done_py:
+            break


### PR DESCRIPTION
## Summary
- add `canonical_state` helper to map GameState into hashable tuples for cross-engine comparison
- introduce parity test that runs Python and Rust engines side-by-side and checks betting consistency using the canonical mapping
- ensure tests can import project modules without installation via `conftest`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd0bc72b30832c93d51e5b761b9ed0