### PR TITLE
Add reset_hand initialization tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
+import types
 from pathlib import Path
 
 # Ensure the repository root is on sys.path so `nlhe` can be imported when the
@@ -6,3 +7,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# Provide a stub for the optional compiled evaluator so ``nlhe.core`` can be
+# imported in environments without the native extension.
+stub = types.SimpleNamespace(best5_rank_from_7_py=lambda cards: (0, ()))
+sys.modules.setdefault("nlhe_engine", stub)
+
+# Import the Python engine module once while the stub is in place so it becomes
+# available to tests even after the stub is removed.
+import nlhe.core.engine  # noqa: F401
+
+# Remove the stub so that attempts to import the optional Rust backend fail,
+# causing parity tests to be skipped when the backend is unavailable.
+sys.modules.pop("nlhe_engine", None)

--- a/tests/test_engine_reset.py
+++ b/tests/test_engine_reset.py
@@ -1,0 +1,33 @@
+import random
+import pytest
+
+from nlhe.core.engine import NLHEngine
+
+
+@pytest.mark.parametrize(
+    "sb, bb, start_stack",
+    [
+        (1, 2, 100),
+        (2, 5, 200),
+        (5, 10, 1000),
+    ],
+)
+def test_reset_hand_initializes_state(sb: int, bb: int, start_stack: int):
+    eng = NLHEngine(sb=sb, bb=bb, start_stack=start_stack, rng=random.Random(0))
+    state = eng.reset_hand(button=0)
+
+    # Pot and betting state
+    assert state.pot == sb + bb
+    assert state.current_bet == bb
+    assert state.next_to_act == (0 + 3) % eng.N
+
+    # Verify hole cards
+    seen_cards = set()
+    for p in state.players:
+        assert p.hole is not None
+        assert len(p.hole) == 2
+        c1, c2 = p.hole
+        assert c1 != c2
+        seen_cards.update(p.hole)
+
+    assert len(seen_cards) == eng.N * 2


### PR DESCRIPTION
## Summary
- test NLHEngine.reset_hand initializes pot, betting state, and hole cards correctly
- add testing stub so engine can load without native extension

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a18d91c832ca5e24b9c8ef6689d