### PR TITLE
Add legal action unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,20 @@
 import sys
 from pathlib import Path
+import types
 
 # Ensure the repository root is on sys.path so `nlhe` can be imported when the
 # project is not installed as a package.
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# Provide a minimal stub for the optional evaluation module so that the
+# engine can be imported without the compiled extension.
+import nlhe.core  # noqa: F401 - ensure package exists
+fake_eval = types.ModuleType("nlhe.core.eval")
+
+def best5_rank_from_7(cards7):
+    return (0, ())
+
+fake_eval.best5_rank_from_7 = best5_rank_from_7
+sys.modules.setdefault("nlhe.core.eval", fake_eval)

--- a/tests/test_engine_legal_actions.py
+++ b/tests/test_engine_legal_actions.py
@@ -1,0 +1,87 @@
+import pytest
+
+from nlhe.core.engine import NLHEngine
+from nlhe.core.types import Action, ActionType
+
+
+def test_owing_chips_can_raise_open_rights():
+    eng = NLHEngine()
+    s = eng.reset_hand(button=0)
+    i = s.next_to_act
+    p = s.players[i]
+    info = eng.legal_actions(s)
+    assert info.actions == [
+        Action(ActionType.FOLD),
+        Action(ActionType.CALL),
+        Action(ActionType.RAISE_TO),
+    ]
+    assert info.min_raise_to == s.current_bet + s.min_raise
+    assert info.max_raise_to == p.bet + p.stack
+    assert info.has_raise_right is True
+
+
+def test_owing_chips_cannot_raise_short_stack():
+    eng = NLHEngine()
+    s = eng.reset_hand(button=0)
+    i = s.next_to_act
+    p = s.players[i]
+    p.stack = eng.owed(s, i)  # only enough to call
+    info = eng.legal_actions(s)
+    assert info.actions == [
+        Action(ActionType.FOLD),
+        Action(ActionType.CALL),
+    ]
+    assert info.min_raise_to is None
+    assert info.max_raise_to is None
+    assert info.has_raise_right is None
+
+
+def test_no_outstanding_bet_check_available():
+    eng = NLHEngine()
+    s = eng.reset_hand(button=0)
+    i = s.next_to_act
+    p = s.players[i]
+    owe = eng.owed(s, i)
+    p.bet += owe
+    p.stack -= owe
+    p.cont += owe
+    s.pot += owe
+    info = eng.legal_actions(s)
+    assert info.actions == [
+        Action(ActionType.CHECK),
+        Action(ActionType.RAISE_TO),
+    ]
+    assert info.min_raise_to == s.current_bet + s.min_raise
+    assert info.max_raise_to == p.bet + p.stack
+    assert info.has_raise_right is True
+
+
+def test_non_active_player_has_no_actions():
+    eng = NLHEngine()
+    s = eng.reset_hand(button=0)
+    i = s.next_to_act
+    p = s.players[i]
+    p.status = "allin"
+    p.stack = 0
+    info = eng.legal_actions(s)
+    assert info.actions == []
+    assert info.min_raise_to is None
+    assert info.max_raise_to is None
+    assert info.has_raise_right is None
+
+
+def test_closed_raise_rights_flagged():
+    eng = NLHEngine()
+    s = eng.reset_hand(button=0)
+    i = s.next_to_act
+    p = s.players[i]
+    p.rho = s.tau  # close raise rights
+    info = eng.legal_actions(s)
+    assert info.actions == [
+        Action(ActionType.FOLD),
+        Action(ActionType.CALL),
+        Action(ActionType.RAISE_TO),
+    ]
+    assert info.min_raise_to == s.current_bet + s.min_raise
+    assert info.max_raise_to == p.bet + p.stack
+    assert info.has_raise_right is False


### PR DESCRIPTION
## Summary
- Stub `nlhe.core.eval` in test suite to import engine without compiled extension
- Add comprehensive tests for legal action generation across various player states

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a3388c4832c8fb74a81b87e4173