### PR TITLE
Add cross-platform build helper for Rust crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ Install in editable mode (builds Rust extensions if toolchain present):
 pip install -e .
 ```
 
+Alternatively, compile the Rust extension crates directly with the cross-platform helper:
+```bash
+python nlhe/build_rust.py --use-maturin --crate-dir nlhe_eval
+python nlhe/build_rust.py --use-maturin --crate-dir rs_engine
+```
+These build the `nlhe_eval` and `rs_engine` crates and install the resulting modules into the active Python environment.
+
 ## 12. Testing & QA Recommendations
 - Verify invariants: `pot == sum(cont)`, `current_bet == max(bet)` after each action
 - Determinism: replay action logs with fixed seed

--- a/nlhe/build_rust.py
+++ b/nlhe/build_rust.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Build and install Rust extension crates across platforms.
+
+This pure-Python helper mirrors the behaviour of the Windows-only
+PowerShell script but works on Linux, macOS and Windows.  It can compile
+both the ``nlhe_eval`` hand evaluator and the ``rs_engine`` backend (or
+any similar ``cdylib`` crate) and install the resulting module into the
+active Python environment using ``maturin`` or plain ``cargo``.
+
+Examples::
+
+    # build the hand evaluator
+    python nlhe/build_rust.py --use-maturin --crate-dir nlhe_eval
+
+    # build the engine backend
+    python nlhe/build_rust.py --use-maturin --crate-dir rs_engine
+
+Run ``python nlhe/build_rust.py --help`` for options.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+import tomllib
+
+
+def run(cmd: list[str], **kwargs) -> None:
+    """Run a subprocess, echoing the command."""
+    print("+", " ".join(cmd))
+    subprocess.check_call(cmd, **kwargs)
+
+
+def ensure_cmd(name: str) -> bool:
+    """Return True if command *name* is available on PATH."""
+    return shutil.which(name) is not None
+
+
+def resolve_python(venv: Path) -> str:
+    """Resolve the Python interpreter within *venv* if it exists."""
+    if os.name == "nt":
+        candidate = venv / "Scripts" / "python.exe"
+    else:
+        candidate = venv / "bin" / "python"
+    if candidate.exists():
+        return str(candidate)
+    print(f"Warning: {candidate} not found, using current interpreter", file=sys.stderr)
+    return sys.executable
+
+
+def get_crate_name(crate: Path) -> str:
+    """Read the Cargo package name for *crate*."""
+    with (crate / "Cargo.toml").open("rb") as fh:
+        data = tomllib.load(fh)
+    return data["package"]["name"]
+
+
+def build_with_maturin(py: str, crate: Path, module: str) -> None:
+    if not ensure_cmd("maturin"):
+        print("maturin not found; installing via pip", file=sys.stderr)
+        run([py, "-m", "pip", "install", "maturin"])
+    run([py, "-m", "maturin", "develop", "--release", "-m", str(crate / "Cargo.toml")])
+    run([py, "-c", f"import {module},sys;print('{module} imported', {module}.__file__)"])
+
+
+def build_with_cargo(py: str, crate: Path, module: str) -> None:
+    if not ensure_cmd("cargo"):
+        raise SystemExit("cargo not found; install Rust toolchain")
+    run(["cargo", "build", "--release"], cwd=crate)
+    ext = {
+        "win32": ".pyd",
+        "cygwin": ".pyd",
+        "msys": ".pyd",
+        "darwin": ".dylib",
+    }.get(sys.platform, ".so")
+    target_dir = crate / "target" / "release"
+    artifact: Path | None = None
+    for root, _, files in os.walk(target_dir):
+        for f in files:
+            if f.startswith(module) and f.endswith(ext):
+                artifact = Path(root) / f
+    if not artifact:
+        raise SystemExit(f"built artifact not found in {target_dir}")
+    site = sysconfig.get_paths().get("platlib", sysconfig.get_paths()["purelib"])
+    dest = Path(site) / (module + ext)
+    shutil.copy2(artifact, dest)
+    print(f"installed {dest}")
+    run([py, "-c", f"import {module},sys;print('{module} imported', {module}.__file__)"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--venv", default=".venv", help="virtual environment path")
+    parser.add_argument("--crate-dir", default="nlhe_eval", help="Rust crate directory")
+    parser.add_argument(
+        "--module-name",
+        help="Python module name (defaults to Cargo package name)",
+    )
+    parser.add_argument("--use-maturin", action="store_true", help="build via maturin develop")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent
+    crate = repo_root / args.crate_dir
+    if not crate.exists():
+        raise SystemExit(f"crate directory {crate!r} not found")
+    module = args.module_name or get_crate_name(crate)
+    py = resolve_python(repo_root / args.venv)
+
+    if args.use_maturin:
+        build_with_maturin(py, crate, module)
+    else:
+        build_with_cargo(py, crate, module)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generalize build script to handle both `nlhe_eval` and `rs_engine`
- document using the helper to compile either Rust crate

## Testing
- `python nlhe/build_rust.py --use-maturin --venv ../.venv --crate-dir nlhe_eval`
- `python nlhe/build_rust.py --use-maturin --venv ../.venv --crate-dir rs_engine`
- `./.venv/bin/python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd1aa006a0832cbfbe136e4d29d7f3