### PR TITLE
Apply shared QSS styling to demo GUI

### DIFF
--- a/nlhe/demo/gui.py
+++ b/nlhe/demo/gui.py
@@ -14,6 +14,7 @@ The demo is intentionally lightweight but demonstrates how to drive the
 from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
+from pathlib import Path
 
 from PyQt6 import QtCore, QtWidgets
 
@@ -29,6 +30,11 @@ class NLHEGui(QtWidgets.QMainWindow):
         super().__init__()
         self.setWindowTitle("NLHE 6-Max GUI")
         self.hero_seat = hero_seat
+
+        # load application wide stylesheet
+        style_file = Path(__file__).with_name("styles.qss")
+        if style_file.exists():
+            self.setStyleSheet(style_file.read_text())
 
         self.controller = GameController(hero_seat=hero_seat, seed=seed)
         self.controller.state_changed.connect(self._on_state_changed)
@@ -88,6 +94,7 @@ class NLHEGui(QtWidgets.QMainWindow):
         btn_layout.addWidget(self.raise_info)
 
         self.status_label = QtWidgets.QLabel("")
+        self.status_label.setObjectName("status-label")
         main.addWidget(self.status_label)
 
         self.log = QtWidgets.QPlainTextEdit()

--- a/nlhe/demo/styles.qss
+++ b/nlhe/demo/styles.qss
@@ -1,0 +1,44 @@
+* {
+    font-family: "Segoe UI", sans-serif;
+}
+
+#player-panel {
+    border: 2px solid black;
+    border-radius: 8px;
+    background: #fcdcda;
+    color: black;
+}
+
+#player-panel[active="true"] {
+    border-color: #280401;
+}
+
+#player-panel[state="folded"] {
+    background: #dddddd;
+}
+
+#player-panel[state="allin"] {
+    background: #ffddaa;
+}
+
+#player-panel[state="called"] {
+    background: #cce0ff;
+}
+
+#player-panel[state="raised"] {
+    background: #c4f5c4;
+}
+
+QLabel#badge {
+    border-radius: 12px;
+    padding: 0 6px;
+    background: #333333;
+    color: white;
+    font-weight: bold;
+}
+
+QLabel#status-label {
+    border-radius: 4px;
+    padding: 2px 4px;
+    background: #e0e0e0;
+}


### PR DESCRIPTION
## Summary
- add `styles.qss` with styling for panels, badges and status labels
- load global QSS in `NLHEGui` and tag status label for styling
- refactor `PlayerPanel` to use object names and QSS properties instead of inline styles
- fix recursive `PlayerPanel.update` call by delegating to `QWidget.update`
- reserve space for bet chip so stack label stays in place

## Testing
- `python build_rust.py --allow-global` *(fails: Couldn't find a virtualenv to use with maturin)*
- `pytest -q` *(fails: ModuleNotFoundError: nlhe_engine; No module named 'PyQt6')*
- `python -m py_compile nlhe/demo/gui.py nlhe/demo/widgets.py`
- `python -m nlhe.demo.gui` *(fails: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68c1ffe62cd0832c93f15d9baceb87af