### PR TITLE
Apply shared QSS styling to demo GUI

### DIFF
--- a/nlhe/demo/gui.py
+++ b/nlhe/demo/gui.py
@@ -14,6 +14,7 @@ The demo is intentionally lightweight but demonstrates how to drive the
 from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
+from pathlib import Path
 
 from PyQt6 import QtCore, QtWidgets
 
@@ -29,6 +30,11 @@ class NLHEGui(QtWidgets.QMainWindow):
         super().__init__()
         self.setWindowTitle("NLHE 6-Max GUI")
         self.hero_seat = hero_seat
+
+        # load application wide stylesheet
+        style_file = Path(__file__).with_name("styles.qss")
+        if style_file.exists():
+            self.setStyleSheet(style_file.read_text())
 
         self.controller = GameController(hero_seat=hero_seat, seed=seed)
         self.controller.state_changed.connect(self._on_state_changed)
@@ -88,6 +94,7 @@ class NLHEGui(QtWidgets.QMainWindow):
         btn_layout.addWidget(self.raise_info)
 
         self.status_label = QtWidgets.QLabel("")
+        self.status_label.setObjectName("status-label")
         main.addWidget(self.status_label)
 
         self.log = QtWidgets.QPlainTextEdit()

--- a/nlhe/demo/gui.py
+++ b/nlhe/demo/gui.py
@@ -95,6 +95,9 @@ class NLHEGui(QtWidgets.QMainWindow):
 
         self.status_label = QtWidgets.QLabel("")
         self.status_label.setObjectName("status-label")
+        self.status_label.setAttribute(
+            QtCore.Qt.WidgetAttribute.WA_StyledBackground, True
+        )
         main.addWidget(self.status_label)
 
         self.log = QtWidgets.QPlainTextEdit()

--- a/nlhe/demo/gui.py
+++ b/nlhe/demo/gui.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Tuple
 from pathlib import Path
 
-from PyQt6 import QtCore, QtWidgets
+from PyQt6 import QtCore, QtWidgets, QtGui
 
 from ..core.types import Action, ActionType, GameState
 from .controller import GameController
@@ -115,6 +115,11 @@ class NLHEGui(QtWidgets.QMainWindow):
         self.next_hand_btn.setEnabled(False)
         self.next_hand_btn.clicked.connect(self._start_next_hand)
         seed_row.addWidget(self.next_hand_btn)
+
+    def resizeEvent(self, event: QtGui.QResizeEvent) -> None:  # pragma: no cover - GUI
+        """Refresh layout when the window size changes."""
+        super().resizeEvent(event)
+        self._update_view()
 
     # ----- helpers -------------------------------------------------------
     def _last_action(self, seat: int) -> Optional[Tuple[int, int]]:

--- a/nlhe/demo/styles.qss
+++ b/nlhe/demo/styles.qss
@@ -1,0 +1,50 @@
+* {
+    font-family: "Segoe UI", sans-serif;
+}
+
+#player-panel {
+    border: 2px solid #000000;
+    border-radius: 8px;
+    background-color: #ffffff;
+    color: #000000;
+}
+
+#player-panel[active="true"] {
+    border-color: #ffeb3b;
+}
+
+#player-panel[state="folded"] {
+    background-color: #9e9e9e;
+    color: #ffffff;
+}
+
+#player-panel[state="allin"] {
+    background-color: #d32f2f;
+    color: #ffffff;
+}
+
+#player-panel[state="called"] {
+    background-color: #1976d2;
+    color: #ffffff;
+}
+
+#player-panel[state="raised"] {
+    background-color: #388e3c;
+    color: #ffffff;
+}
+
+QLabel#badge {
+    border-radius: 12px;
+    padding: 0 6px;
+    background-color: #212121;
+    color: #ffffff;
+    font-weight: bold;
+}
+
+QLabel#status-label {
+    border-radius: 4px;
+    padding: 2px 4px;
+    background-color: #424242;
+    color: #ffffff;
+    font-weight: bold;
+}

--- a/nlhe/demo/widgets.py
+++ b/nlhe/demo/widgets.py
@@ -93,30 +93,51 @@ class ChipLabel(QtWidgets.QLabel):
         self.setPixmap(self.pixmap())
 
 
-class BetChip(QtWidgets.QLabel):
-    """Chip-style label showing the player's current bet with animation."""
+class BetChip(QtWidgets.QWidget):
+    """Chip-style widget showing the player's current bet with animation."""
 
     def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
         super().__init__(parent)
+        self._amt = 0
         self._base = 32
+        self._max = int(self._base * 1.5)
         self._apply_size(self._base)
-        self.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        self.setStyleSheet(
-            "border-radius:16px; background:#d43333; color:white; font-weight:bold;",
-        )
         self._effect = QtWidgets.QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(self._effect)
         self._effect.setOpacity(1.0)
 
     def _apply_size(self, s: int) -> None:
+        self._size = s
         self.setFixedSize(s, s)
-        font = self.font()
-        font.setPointSize(max(8, int(s / 2)))
-        self.setFont(font)
+        self.update()
+
+    @property
+    def max_size(self) -> int:
+        return self._max
 
     def set_amount(self, amt: int) -> None:
-        self.setText(str(amt))
+        self._amt = amt
         self.setVisible(amt > 0)
+        self.update()
+
+    def paintEvent(self, _: QtGui.QPaintEvent) -> None:  # pragma: no cover - GUI paint
+        p = QtGui.QPainter(self)
+        p.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+        s = self._size
+        p.setBrush(QtGui.QColor("#d43333"))
+        p.setPen(QtGui.QPen(QtGui.QColor("white"), 2))
+        p.drawEllipse(0, 0, s - 1, s - 1)
+        p.drawEllipse(3, 3, s - 7, s - 7)
+        p.setPen(QtGui.QPen(QtGui.QColor("white"), 3))
+        for ang in range(0, 360, 45):
+            p.drawArc(3, 3, s - 7, s - 7, ang * 16, 10 * 16)
+        font = p.font()
+        font.setBold(True)
+        font.setPointSize(max(8, int(s / 2)))
+        p.setFont(font)
+        p.setPen(QtGui.QColor("white"))
+        p.drawText(self.rect(), QtCore.Qt.AlignmentFlag.AlignCenter, str(self._amt))
+        p.end()
 
     def animate(self) -> None:
         self._effect.setOpacity(0.0)
@@ -129,7 +150,7 @@ class BetChip(QtWidgets.QLabel):
 
         scale = QtCore.QVariantAnimation(self)
         scale.setDuration(500)
-        scale.setStartValue(self._base * 1.4)
+        scale.setStartValue(self._max)
         scale.setEndValue(self._base)
         scale.valueChanged.connect(lambda v: self._apply_size(int(v)))
 
@@ -144,6 +165,7 @@ class PlayerPanel(QtWidgets.QFrame):
     def __init__(self, seat: int) -> None:
         super().__init__()
         self.seat = seat
+        self.setObjectName("player-panel")
         self.setFrameShape(QtWidgets.QFrame.Shape.Box)
         lay = QtWidgets.QVBoxLayout(self)
         lay.setContentsMargins(4, 4, 4, 4)
@@ -156,9 +178,7 @@ class PlayerPanel(QtWidgets.QFrame):
         self.seat_label = QtWidgets.QLabel(f"Seat {seat}")
         self.seat_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self.seat_label.setFixedHeight(24)
-        self.seat_label.setStyleSheet(
-            "border-radius:12px; padding:0 6px; background:#333333; color:white;",
-        )
+        self.seat_label.setObjectName("badge")
         info_row.addWidget(self.seat_label)
 
         info_row.addStretch(1)
@@ -171,7 +191,14 @@ class PlayerPanel(QtWidgets.QFrame):
         info_row.addWidget(self.stack_label)
 
         self.bet_chip = BetChip()
-        info_row.addWidget(self.bet_chip)
+        # Reserve space for bet chip including animation oversize
+        self.bet_box = QtWidgets.QWidget()
+        self.bet_box.setFixedSize(self.bet_chip.max_size, self.bet_chip.max_size)
+        bet_lay = QtWidgets.QHBoxLayout(self.bet_box)
+        bet_lay.setContentsMargins(0, 0, 0, 0)
+        bet_lay.addStretch(1)
+        bet_lay.addWidget(self.bet_chip)
+        info_row.addWidget(self.bet_box)
 
         lay.addLayout(info_row)
 
@@ -182,6 +209,7 @@ class PlayerPanel(QtWidgets.QFrame):
         lay.addLayout(cards_row)
 
         self.last = QtWidgets.QLabel("")
+        self.last.setObjectName("status-label")
         lay.addWidget(self.last)
 
         self._last_bet = 0
@@ -204,29 +232,34 @@ class PlayerPanel(QtWidgets.QFrame):
         self._last_bet = p.bet
 
         last_txt = ""
-        bg = "#fcdcda"
+        state = "default"
         if p.status == "folded":
-            bg = "#dddddd"
+            state = "folded"
             last_txt = "fold"
         elif p.status == "allin":
-            bg = "#ffddaa"
+            state = "allin"
             last_txt = "all-in"
         elif last is not None:
             aid, amt = last
             if aid == 1:
                 last_txt = "check"
             elif aid == 2:
-                last_txt = "call"; bg = "#cce0ff"
+                state = "called"
+                last_txt = "call"
             elif aid == 3:
-                last_txt = f"raise to {amt}"; bg = "#c4f5c4"
+                state = "raised"
+                last_txt = f"raise to {amt}"
             else:
-                last_txt = "fold"; bg = "#dddddd"
+                state = "folded"
+                last_txt = "fold"
         self.last.setText(last_txt)
 
-        border = "#280401" if active else "black"
-        self.setStyleSheet(
-            f"border: 2px solid {border}; color: black; background-color: {bg};",
-        )
+        self.setProperty("active", active)
+        self.setProperty("state", state)
+        self.style().unpolish(self)
+        self.style().polish(self)
+        # call QWidget.update to refresh after re-polishing style
+        super().update()
 
 
 class BoardWidget(QtWidgets.QWidget):

--- a/nlhe/demo/widgets.py
+++ b/nlhe/demo/widgets.py
@@ -166,6 +166,8 @@ class PlayerPanel(QtWidgets.QFrame):
         super().__init__()
         self.seat = seat
         self.setObjectName("player-panel")
+        # allow QSS background colors to fully apply
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_StyledBackground, True)
         self.setFrameShape(QtWidgets.QFrame.Shape.Box)
         lay = QtWidgets.QVBoxLayout(self)
         lay.setContentsMargins(4, 4, 4, 4)
@@ -179,6 +181,9 @@ class PlayerPanel(QtWidgets.QFrame):
         self.seat_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self.seat_label.setFixedHeight(24)
         self.seat_label.setObjectName("badge")
+        self.seat_label.setAttribute(
+            QtCore.Qt.WidgetAttribute.WA_StyledBackground, True
+        )
         info_row.addWidget(self.seat_label)
 
         info_row.addStretch(1)
@@ -210,7 +215,21 @@ class PlayerPanel(QtWidgets.QFrame):
 
         self.last = QtWidgets.QLabel("")
         self.last.setObjectName("status-label")
+        self.last.setAttribute(
+            QtCore.Qt.WidgetAttribute.WA_StyledBackground, True
+        )
         lay.addWidget(self.last)
+
+        margins = lay.contentsMargins()
+        min_width = (
+            self.seat_label.sizeHint().width()
+            + self.stack_label.sizeHint().width()
+            + self.bet_box.width()
+            + info_row.spacing() * 2
+            + margins.left()
+            + margins.right()
+        )
+        self.setMinimumWidth(min_width)
 
         self._last_bet = 0
 


### PR DESCRIPTION
## Summary
- add `styles.qss` with styling for panels, badges and status labels
- load global QSS in `NLHEGui` and tag status label for styling
- refactor `PlayerPanel` to use object names and QSS properties instead of inline styles
- fix recursive `PlayerPanel.update` call by delegating to `QWidget.update`
- reserve space for bet chip so stack label stays in place
- refine QSS colors to use explicit hex values and improve text contrast
- draw chip-style bet indicator with animation-safe placeholder to avoid overlap

## Testing
- `python build_rust.py --allow-global` *(fails: Couldn't find a virtualenv or conda environment)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nlhe_engine'; No module named 'PyQt6')*
- `python -m py_compile nlhe/demo/gui.py nlhe/demo/widgets.py`
- `QT_QPA_PLATFORM=offscreen python -m nlhe.demo.gui` *(fails: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68c1ffe62cd0832c93f15d9baceb87af