### PR TITLE
Add icons and themed action buttons

### DIFF
--- a/nlhe/demo/assets/icons/call.svg
+++ b/nlhe/demo/assets/icons/call.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <line
+    x1="4" y1="12" x2="16" y2="12"
+    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+  />
+  <polyline
+    points="12,8 16,12 12,16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/nlhe/demo/assets/icons/check.svg
+++ b/nlhe/demo/assets/icons/check.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <polyline
+    points="4,12 9,17 20,6"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/nlhe/demo/assets/icons/fold.svg
+++ b/nlhe/demo/assets/icons/fold.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <line x1="4" y1="4" x2="20" y2="20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <line x1="20" y1="4" x2="4" y2="20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/nlhe/demo/assets/icons/raise.svg
+++ b/nlhe/demo/assets/icons/raise.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <polyline
+    points="4,14 12,6 20,14"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <line
+    x1="12" y1="6" x2="12" y2="20"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+</svg>

--- a/nlhe/demo/gui.py
+++ b/nlhe/demo/gui.py
@@ -72,9 +72,68 @@ class NLHEGui(QtWidgets.QMainWindow):
         btn_layout = QtWidgets.QHBoxLayout()
         main.addLayout(btn_layout)
         self.action_buttons: Dict[str, QtWidgets.QPushButton] = {}
-        for name in ["FOLD", "CHECK", "CALL", "RAISE"]:
+
+        icons_dir = Path(__file__).with_name("assets") / "icons"
+        btn_specs = {
+            # colours align with player panel states in styles.qss
+            "FOLD": (
+                "fold.svg",
+                "#9e9e9e",
+                "#c4c4c4",
+                "Forfeit the hand",
+            ),
+            "CHECK": (
+                "check.svg",
+                "#4c5f54",
+                "#939f98",
+                "Pass action without betting",
+            ),
+            "CALL": (
+                "call.svg",
+                "#4c5f54",
+                "#939f98",
+                "Match the current bet",
+            ),
+            "RAISE": (
+                "raise.svg",
+                "#ea9c28",
+                "#f2c37e",
+                "Increase the bet amount",
+            ),
+        }
+
+        for name, (icon_file, color, disabled, tip) in btn_specs.items():
             btn = QtWidgets.QPushButton(name)
+            btn.setIcon(QtGui.QIcon(str(icons_dir / icon_file)))
+            btn.setIconSize(QtCore.QSize(16, 16))
+            btn.setStyleSheet(
+                "QPushButton {"
+                f"background-color: {color}; color: white; font-weight: bold;"
+                "}"
+                "QPushButton:disabled {"
+                f"background-color: {disabled}; color: white;"
+                "}"
+            )
+            btn.setToolTip(tip)
             btn.clicked.connect(lambda _, n=name: self._on_action(n))
+
+            # simple press animation to give visual feedback
+            effect = QtWidgets.QGraphicsOpacityEffect(btn)
+            btn.setGraphicsEffect(effect)
+            anim = QtCore.QSequentialAnimationGroup(btn)
+            fade_out = QtCore.QPropertyAnimation(effect, b"opacity")
+            fade_out.setDuration(100)
+            fade_out.setStartValue(1.0)
+            fade_out.setEndValue(0.3)
+            fade_in = QtCore.QPropertyAnimation(effect, b"opacity")
+            fade_in.setDuration(150)
+            fade_in.setStartValue(0.3)
+            fade_in.setEndValue(1.0)
+            anim.addAnimation(fade_out)
+            anim.addAnimation(fade_in)
+            btn.pressed.connect(anim.start)
+            btn._press_anim = anim  # keep reference
+
             btn_layout.addWidget(btn)
             self.action_buttons[name] = btn
 

--- a/nlhe/demo/styles.qss
+++ b/nlhe/demo/styles.qss
@@ -44,7 +44,26 @@ QLabel#badge {
 QLabel#status-label {
     border-radius: 4px;
     padding: 2px 4px;
-    background-color: #8f049cff;
     color: #ffffff;
     font-weight: bold;
+}
+
+QLabel#status-label[state="default"] {
+    background-color: #8f049cff;
+}
+
+QLabel#status-label[state="folded"] {
+    background-color: #9e9e9e;
+}
+
+QLabel#status-label[state="allin"] {
+    background-color: #d32f2f;
+}
+
+QLabel#status-label[state="called"] {
+    background-color: #4c5f54ff;
+}
+
+QLabel#status-label[state="raised"] {
+    background-color: #ea9c28ff;
 }

--- a/nlhe/demo/widgets.py
+++ b/nlhe/demo/widgets.py
@@ -268,6 +268,11 @@ class PlayerPanel(QtWidgets.QFrame):
         self.last.setAttribute(
             QtCore.Qt.WidgetAttribute.WA_StyledBackground, True
         )
+        self.last.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+        self.last.setFixedHeight(24)
         lay.addWidget(self.last)
 
         margins = lay.contentsMargins()
@@ -322,6 +327,9 @@ class PlayerPanel(QtWidgets.QFrame):
                 state = "folded"
                 last_txt = "fold"
         self.last.setText(last_txt)
+        self.last.setProperty("state", state)
+        self.last.style().unpolish(self.last)
+        self.last.style().polish(self.last)
 
         self.setProperty("active", active)
         self.setProperty("state", state)


### PR DESCRIPTION
## Summary
- add SVG icons for poker actions
- style action buttons with themed colors and tooltips
- match action button colors to player-panel theme and add press animations
- align player panel status label colors with corresponding actions

## Testing
- `pip install PyQt6`
- `python build_rust.py` *(aborted: virtual environment required)*
- `python build_rust.py` *(compiled nlhe_eval and nlhe_engine wheels)*
- `pytest -q` *(fails: ValueError: cannot CALL when owe==0)*

------
https://chatgpt.com/codex/tasks/task_e_68c2190b2104832cb4f061b35913388d