### PR TITLE
Use Rust GameState directly in rs_engine

### DIFF
--- a/nlhe/core/rs_engine.py
+++ b/nlhe/core/rs_engine.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List, Optional, Tuple
 import random
-from .types import Action as PyAction, ActionType, PlayerState as PyPlayerState
-from .types import GameState as PyGameState, LegalActionInfo as PyLegalActionInfo
+from .types import Action as PyAction, ActionType, LegalActionInfo as PyLegalActionInfo
 
 try:
     import nlhe_engine as _rs
@@ -32,32 +31,6 @@ def _from_rs_legal(li: _rs.LegalActionInfo) -> PyLegalActionInfo:
         has_raise_right=None if li.has_raise_right is None else bool(li.has_raise_right),
     )
 
-def _apply_diff_inplace(s: PyGameState, diff: _rs.StepDiff) -> None:
-    # cheap scalars
-    s.next_to_act = diff.next_to_act
-    s.step_idx    = int(diff.step_idx)
-    s.current_bet = int(diff.current_bet)
-    s.min_raise   = int(diff.min_raise)
-    s.tau         = int(diff.tau)
-    s.pot         = int(diff.pot)
-    if diff.round_label is not None:
-        s.round_label = str(diff.round_label)
-    # add dealt cards
-    if diff.board_drawn:
-        s.board.extend(int(c) for c in diff.board_drawn)
-    # append last log if present
-    if diff.actions_log_push is not None:
-        s.actions_log.append(tuple(int(x) for x in diff.actions_log_push))
-    # per-player updates
-    for pu in diff.player_updates:
-        i = int(pu.idx)
-        p = s.players[i]
-        p.stack = int(pu.stack)
-        p.bet   = int(pu.bet)
-        p.cont  = int(pu.cont)
-        p.rho   = int(pu.rho)
-        if pu.status is not None:
-            p.status = str(pu.status)
 
 class NLHEngine:
     def __init__(self, sb: int = 1, bb: int = 2, start_stack: int = 100,
@@ -88,54 +61,20 @@ class NLHEngine:
         # reusable LegalActionInfo (we just mutate its fields)
         self._la_reusable = PyLegalActionInfo(actions=[], min_raise_to=None, max_raise_to=None, has_raise_right=None)
         
-        # State management for optimization 2 (in-place reset)
-        self._state = None
-        
-        # Cache for in-place reset
         self._state = None
 
-    def reset_hand(self, button: int = 0) -> PyGameState:
+    def reset_hand(self, button: int = 0):
         if self._state is None:
-            # Create once by asking Rust for a full snapshot, then reuse forever.
-            self._state = self._create_initial_state(button)
+            self._state = self._rs.reset_hand(int(button))
         else:
-            # Fast path: mutate in place and return the same object (API compatible)
             self._rs.reset_hand_apply_py(self._state, int(button))
         return self._state
 
-    def _create_initial_state(self, button: int) -> PyGameState:
-        # one-time snapshot to create the Python mirror
-        s_rs = self._rs.reset_hand(int(button))
-        # convert once (initial)
-        players = []
-        for pr in s_rs.players:
-            players.append(PyPlayerState(
-                hole=None if pr.hole is None else (int(pr.hole[0]), int(pr.hole[1])),
-                stack=int(pr.stack), bet=int(pr.bet), cont=int(pr.cont),
-                status=str(pr.status), rho=int(pr.rho)
-            ))
-        s = PyGameState(
-            button=int(s_rs.button),
-            round_label=str(s_rs.round_label),
-            board=[int(x) for x in s_rs.board],
-            undealt=[int(x) for x in s_rs.undealt],
-            players=players,
-            current_bet=int(s_rs.current_bet),
-            min_raise=int(s_rs.min_raise),
-            tau=int(s_rs.tau),
-            next_to_act=None if s_rs.next_to_act is None else int(s_rs.next_to_act),
-            step_idx=int(s_rs.step_idx),
-            pot=int(s_rs.pot),
-            sb=self.sb, bb=self.bb,
-            actions_log=[(int(i),int(a),int(v),int(r)) for (i,a,v,r) in s_rs.actions_log],
-        )
-        return s
-
     # Cheap helper stays in Python
-    def owed(self, s: PyGameState, i: int) -> int:
+    def owed(self, s, i: int) -> int:
         return max(0, int(s.current_bet) - int(s.players[i].bet))
 
-    def legal_actions(self, s: PyGameState) -> PyLegalActionInfo:
+    def legal_actions(self, s) -> PyLegalActionInfo:
         mask, min_to, max_to, has_rr = self._rs.legal_actions_bits_now()
         la = self._la_reusable
         la.actions = self._mask_cache[int(mask)]  # tuple of cached singletons
@@ -151,13 +90,13 @@ class NLHEngine:
             has_raise_right=la.has_raise_right
         )
 
-    def step(self, s: PyGameState, a: PyAction) -> Tuple[PyGameState, bool, Optional[List[int]], Dict[str, Any]]:
+    def step(self, s, a: PyAction) -> Tuple[Any, bool, Optional[List[int]], Dict[str, Any]]:
         # map Action → two scalars (no PyO3 Action at all)
         kind = _ACTION_ID[a.kind]
         amt = None if a.amount is None else int(a.amount)
         done, rewards = self._rs.step_apply_py_raw(s, kind, amt)
         return s, bool(done), (None if rewards is None else [int(x) for x in rewards]), {}
 
-    def advance_round_if_needed(self, s: PyGameState) -> Tuple[bool, Optional[List[int]]]:
+    def advance_round_if_needed(self, s) -> Tuple[bool, Optional[List[int]]]:
         done, rewards = self._rs.advance_round_if_needed_apply_py(s)
         return bool(done), (None if rewards is None else [int(x) for x in rewards])

--- a/test_round_reset.py
+++ b/test_round_reset.py
@@ -4,7 +4,14 @@ Test to verify that round reset behavior works correctly when transitioning betw
 This test checks that player.bet values are properly reset to 0 when advancing from preflop to flop.
 """
 
-import nlhe_engine
+import importlib.util, importlib.machinery, pathlib
+spec = importlib.util.find_spec("nlhe_engine")
+suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+lib_path = pathlib.Path(spec.origin).with_name(f"nlhe_engine{suffix}")
+spec = importlib.util.spec_from_file_location("nlhe_engine", lib_path)
+nlhe_engine = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(nlhe_engine)  # type: ignore[arg-type]
 from nlhe.core.types import ActionType
 
 def test_round_reset():
@@ -43,32 +50,31 @@ def test_round_reset():
     print(f"Next to act: {state.next_to_act}")
     assert not done
     
-    # Let's have remaining players all call to keep multiple players active
-    while state.next_to_act is not None:
-        print(f"Player {state.next_to_act} calling")
-        done, rewards = engine.step_apply_py_raw(state, 2, None)  # CALL
+    # Let remaining players act until round completion.
+    # Players who owe chips must CALL; others simply CHECK.
+    while state.next_to_act is not None and state.round_label == "Preflop":
+        idx = state.next_to_act
+        owe = state.current_bet - state.players[idx].bet
+        # The big blind (or any fully invested player) owes zero chips and must CHECK; CALL would raise ValueError.
+        action = 2 if owe > 0 else 1  # 0=FOLD,1=CHECK,2=CALL,3=RAISE_TO
+        print(f"Player {idx} taking action {ActionType(action + 1).name}")
+        done, rewards = engine.step_apply_py_raw(state, action, None)
         print(f"Player bets: {[p.bet for p in state.players]}")
-        if done:
-            print("Game ended unexpectedly")
-            return
-    
+        assert not done
+
     print(f"Preflop round finished, next_to_act: {state.next_to_act}")
-    
-    # Check that all players have non-zero bets
-    print("Player bets before round advance:", [p.bet for p in state.players])
-    assert any(p.bet > 0 for p in state.players), "No players have bets > 0"
-    
-    print("=== Before Round Advance ===")
-    print(f"Round: {state.round_label}")
-    print(f"Current bet: {state.current_bet}")
-    print("Player bets:", [p.bet for p in state.players])
-    print("Board length:", len(state.board))
-    print()
-    
-    # Now advance the round (should transition to flop)
+
+    # After the final CHECK by the big blind the round should have advanced
+    # automatically to the flop, resetting all player bets to zero.
+    assert state.round_label == "Flop"
+    print("Player bets before verification:", [p.bet for p in state.players])
+
+    # Calling advance_round_if_needed_apply_py should now be a no-op since the
+    # round has already advanced. This exercises the helper but does not change
+    # the state.
     done, rewards = engine.advance_round_if_needed_apply_py(state)
-    
-    print("=== After Round Advance ===")
+
+    print("=== After Round Advance Check ===")
     print(f"Round: {state.round_label}")
     print(f"Current bet: {state.current_bet}")
     print("Player bets:", [p.bet for p in state.players])
@@ -76,7 +82,7 @@ def test_round_reset():
     print("Board length:", len(state.board))
     print("Board:", state.board)
     print()
-    
+
     # Verify the round was properly reset
     assert state.round_label == "Flop", f"Expected 'Flop', got '{state.round_label}'"
     assert state.current_bet == 0, f"Expected current_bet=0, got {state.current_bet}"

--- a/tests/test_engine_binding.py
+++ b/tests/test_engine_binding.py
@@ -1,0 +1,30 @@
+import importlib.util, importlib.machinery, pathlib
+spec = importlib.util.find_spec("nlhe_engine")
+suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+lib_path = pathlib.Path(spec.origin).with_name(f"nlhe_engine{suffix}")
+spec = importlib.util.spec_from_file_location("nlhe_engine", lib_path)
+nlhe_engine = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(nlhe_engine)  # type: ignore[arg-type]
+
+
+def test_step_apply_updates_python_state():
+    engine = nlhe_engine.NLHEngine(sb=1, bb=2, start_stack=100, seed=0)
+    state = engine.reset_hand(button=0)
+    actor = state.next_to_act
+    assert actor is not None
+    done, _ = engine.step_apply_py_raw(state, 2, None)
+    assert not done
+    assert state.players[actor].bet == state.current_bet
+
+
+def test_round_advance_resets_bets():
+    engine = nlhe_engine.NLHEngine(sb=1, bb=2, start_stack=100, seed=0)
+    state = engine.reset_hand(button=0)
+    while state.round_label == "Preflop":
+        player = state.players[state.next_to_act]
+        owe = max(0, state.current_bet - player.bet)
+        action = 2 if owe > 0 else 1
+        engine.step_apply_py_raw(state, action, None)
+    assert state.round_label == "Flop"
+    assert all(p.bet == 0 for p in state.players)

--- a/tests/test_rs_wrapper.py
+++ b/tests/test_rs_wrapper.py
@@ -1,0 +1,22 @@
+import nlhe.core.rs_engine as rs
+from nlhe.core.types import Action, ActionType
+
+def test_step_and_round_reset_wrapper():
+    eng = rs.NLHEngine(sb=1, bb=2, start_stack=100)
+    state = eng.reset_hand(button=0)
+    assert state.round_label == "Preflop"
+    # player 3 calls, player 4 calls
+    eng.step(state, Action(ActionType.CALL))
+    assert state.players[3].bet == 2
+    eng.step(state, Action(ActionType.CALL))
+    assert state.players[4].bet == 2
+    # let remaining players act
+    while state.next_to_act is not None and state.round_label == "Preflop":
+        idx = state.next_to_act
+        owe = state.current_bet - state.players[idx].bet
+        act = Action(ActionType.CALL if owe > 0 else ActionType.CHECK)
+        eng.step(state, act)
+    # round should have advanced
+    assert state.round_label == "Flop"
+    assert len(state.board) == 3
+    assert all(p.bet == 0 for p in state.players)


### PR DESCRIPTION
## Summary
- Reuse a single Rust `GameState` inside the high-level engine, resetting it in place and forwarding actions as raw scalars
- Clone the internal state directly into a Python `GameState` after steps or round advances, keeping players, board, and logs synchronized
- Add regression tests verifying player bets update and round resets deal the flop correctly

## Testing
- `pytest tests/test_engine_binding.py tests/test_rs_wrapper.py test_round_reset.py -q`
- `python speed_comparison.py --skip-features --skip-single-points --skip-edge-cases --skip-memory-tests --reset-tests 100 --step-tests 100 --hand-tests 1000`


------
https://chatgpt.com/codex/tasks/task_e_68c20e0c48ec832c881d88f1c553a7f2